### PR TITLE
Better Parameterize Build Scripts, Add Example Github Action for Building

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,91 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25
+        with:
+          cosign-release: 'v1.9.0'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-ARG ENVOY_VERSION
-ARG CONSUL_VERSION
+### CONFIGURATION ###
+#
+# These values will be used by the Github Action to build images.
+# Modify these in a PR, merge them, and push a tag with format 'v<YOUR_VERSION_HERE>' to auto-build a new image!
+#
+ARG ENVOY_IMAGE=envoyproxy/envoy:v1.23.1
+ARG CONSUL_IMAGE=hashicorp/consul:1.13.1
+#
+### END CONFIGURATION ###
 
-FROM envoyproxy/envoy:v${ENVOY_VERSION} as envoy-bin
+FROM ${ENVOY_IMAGE} as envoy-bin
 
-FROM consul:${CONSUL_VERSION} as consul-bin
+FROM ${CONSUL_IMAGE} as consul-bin
 
 FROM ubuntu 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ### CONFIGURATION ###
 #
-# These values will be used by the Github Action to build images.
-# Modify these in a PR, merge them, and push a tag with format 'v<YOUR_VERSION_HERE>' to auto-build a new image!
+# These default values can be used by a Github Action to build images, if enabled.
 #
 ARG ENVOY_IMAGE=envoyproxy/envoy:v1.23.1
 ARG CONSUL_IMAGE=hashicorp/consul:1.13.1

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,32 @@
 .PHONY: build build_and_push
-DOCKER_REPOSITORY="nicholasjackson/consul-envoy"
-CONSUL_VERSION=1.8.0
-ENVOY_VERSION=1.12.4
+
+### CONFIGURATION ###
+#
+# Can be overridden by passing ENV variables to `make`
+#
+# Example : DOCKERHUB_REPO=ericreeves/consul-envoy CONSUL_REPO=hashicorp/consul-enterprise CONSUL_VERSION=1.13.1-ent make build_and_push
+#
+
+# Consul Base Repository and Image Tag
+CONSUL_REPO    ?= hashicorp/consul
+CONSUL_VERSION ?= 1.13.1
+
+# Envoy Base Repository and Image Tag
+ENVOY_REPO     ?= envoyproxy/envoy
+ENVOY_VERSION  ?= 1.23.1
+
+# Dockerhub Base Repository and Image Tag for our envoy-consul Image
+DOCKERHUB_REPO ?= nicholasjackson/consul-envoy
+
+### END CONFIGURATION ###
+
+# Construct Full Image Names
+CONSUL_IMAGE=${CONSUL_REPO}:${CONSUL_VERSION}
+ENVOY_IMAGE=${ENVOY_REPO}:v${ENVOY_VERSION}
+DOCKERHUB_IMAGE=${DOCKERHUB_REPO}:v${CONSUL_VERSION}-v${ENVOY_VERSION}
 
 build:
-	docker build --build-arg CONSUL_VERSION=${CONSUL_VERSION} --build-arg ENVOY_VERSION=${ENVOY_VERSION} -t "${DOCKER_REPOSITORY}:v${CONSUL_VERSION}-v${ENVOY_VERSION}" .
+	docker build --build-arg CONSUL_IMAGE=${CONSUL_IMAGE} --build-arg ENVOY_IMAGE=${ENVOY_IMAGE} -t "${DOCKERHUB_IMAGE}" .
 
 build_and_push: build
-	docker push "${DOCKER_REPOSITORY}:v${CONSUL_VERSION}-v${ENVOY_VERSION}"
+	docker push "${DOCKERHUB_IMAGE}"

--- a/batch_generate.sh
+++ b/batch_generate.sh
@@ -4,33 +4,33 @@ function docker_tag_exists() {
   curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
 }
 
-consul_version=("1.12.2" "1.12.0" "1.11.2" "1.10.7" "1.10.0" "1.9.5" "1.9.3" "1.9.2" "1.8.3" "1.8.2" "1.8.1" "1.8.0" "1.7.4" "1.7.3" "1.7.2")
-envoy_version=("1.22.2" "1.22.1" "1.22.0" "1.21.2" "1.20.1" "1.18.1" "1.18.4" "1.18.3" "1.17.1" "1.16.2" "1.16.0" "1.15.3" "1.15.0" "1.14.4" "1.14.2" "1.13.4" "1.13.2" "1.13.1" "1.13.0" "1.12.6" "1.12.4" "1.12.3" "1.11.2" "1.10.0")
+# This can be overriden by passing an environment variable
+: ${DOCKERHUB_USERNAME:="nicholasjackson"}
 
-#consul_version=("1.10.0" "1.9.5" "1.9.3" "1.9.2")
-#envoy_version=("1.18.3" "1.17.1" "1.16.2" "1.16.0")
+CONSUL_REPO="hashicorp/consul"
+CONSUL_VERSION=("1.12.2" "1.12.0" "1.11.2" "1.10.7" "1.10.0" "1.9.5" "1.9.3" "1.9.2" "1.8.3" "1.8.2" "1.8.1" "1.8.0" "1.7.4" "1.7.3" "1.7.2")
 
-# consul_version=("1.9.5")
-# envoy_version=("1.16.2")
+ENVOY_REPO="envoyproxy/envoy"
+ENVOY_VERSION=("1.22.2" "1.22.1" "1.22.0" "1.21.2" "1.20.1" "1.18.1" "1.18.4" "1.18.3" "1.17.1" "1.16.2" "1.16.0" "1.15.3" "1.15.0" "1.14.4" "1.14.2" "1.13.4" "1.13.2" "1.13.1" "1.13.0" "1.12.6" "1.12.4" "1.12.3" "1.11.2" "1.10.0")
 
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx create --name multi || true
 docker buildx use multi
 docker buildx inspect --bootstrap
 
-for c in ${consul_version[@]};do
-	for e in ${envoy_version[@]};do
+for c in ${CONSUL_VERSION[@]};do
+	for e in ${ENVOY_VERSION[@]};do
     # only build if the image does not exist in the repo
-    if docker_tag_exists  nicholasjackson/consul-envoy v$c-v$e; then
-      echo "Docker image nicholasjackson/consul-envoy v$c-v$e, already exists, skip build"
+    if docker_tag_exists  ${DOCKERHUB_USERNAME}/consul-envoy v$c-v$e; then
+      echo "Docker image ${DOCKERHUB_USERNAME}/consul-envoy v$c-v$e, already exists, skip build"
     else
-      echo "Building Docker image nicholasjackson/consul-envoy v$c-v$e"
+      echo "Building Docker image ${DOCKERHUB_USERNAME}/consul-envoy v$c-v$e"
       echo ""
 
       docker buildx build --platform linux/arm64,linux/amd64 \
-        --build-arg CONSUL_VERSION=$c \
-        --build-arg ENVOY_VERSION=$e \
-        -t nicholasjackson/consul-envoy:v$c-v$e \
+        --build-arg CONSUL_IMAGE=${CONSUL_REPO}:$c \
+        --build-arg ENVOY_IMAGE=${ENVOY_REPO}:v$e \
+        -t ${DOCKERHUB_USERNAME}/consul-envoy:v$c-v$e \
          . \
       	--push
     fi

--- a/examples/docker-publish-ghcr.yml
+++ b/examples/docker-publish-ghcr.yml
@@ -1,3 +1,8 @@
+###########################################################################
+# To utilize this Action to build images and publish them to GHCR,
+# copy this file to .github/workflows in your repository and commit/push!
+###########################################################################
+
 name: Docker
 
 # This workflow uses actions that are not certified by GitHub.
@@ -10,8 +15,6 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ "main" ]
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
This PR better parameterizes the build scripts to easily build images with any Consul/Envoy version.

Also includes an example Github Action that is disabled by default that will automagically build Docker images and publish them to a Github Container Registry when a tag with format "v<YOUR_VERSION_STRING>" is pushed to the "main" branch.

It also retains backward compatibility with former behavior.  :)